### PR TITLE
feat: fix correctness, decouple network rates, clean up stats plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,4 @@
 /target
+.scratch/
+.state/
+docs/adr/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -526,7 +526,7 @@ dependencies = [
 
 [[package]]
 name = "stats_provider"
-version = "0.8.2"
+version = "0.9.0"
 dependencies = [
  "anyhow",
  "cc",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "stats_provider"
-version = "0.8.2"
+version = "0.9.0"
 description = "A simple system stats event provider for Sketchybar."
 edition = "2024"
 build = "build.rs"

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Options:
   -c, --cpu <CPU>...                               Get CPU stats [possible values: count, frequency, temperature, usage]
   -d, --disk <DISK>...                             Get disk stats [possible values: count, free, total, usage, used]
   -m, --memory <MEMORY>...                         Get memory stats [possible values: ram_available, ram_total, ram_usage, ram_used, swp_free, swp_total, swp_usage, swp_used]
-  -n, --network <NETWORK>...                       Network rx/tx in KB/s. Specify network interfaces (e.g., -n eth0 en0 lo0). At least one is required.
+  -n, --network <NETWORK>...                       Network rx/tx in KiB/s. Specify network interfaces (e.g., -n eth0 en0 lo0). At least one is required.
   -s, --system <SYSTEM>...                         Get system stats [possible values: arch, distro, host_name, kernel_version, name, os_version, long_os_version]
   -u, --uptime <UPTIME>...                         Get uptime stats [possible values: week, day, hour, min, sec]
   -i, --interval <INTERVAL>                        Refresh interval in seconds [default: 5]
@@ -107,7 +107,7 @@ Units are automatically sorted from largest to smallest, with intelligent carry-
 
 ### Output Format
 
-By default, all numeric values include their units (MHz, °C, %, GB, KB/s). You can output raw numeric values without units using the `--no-units` flag:
+By default, all numeric values include their units (MHz, °C, %, GB, KiB/s). You can output raw numeric values without units using the `--no-units` flag:
 
 ```bash
 # With units (default)
@@ -178,8 +178,8 @@ Environment variables that can be provided by the `system_stats` event
 | `DISTRO`                 | System distribution                       |
 | `HOST_NAME`              | System host name                          |
 | `KERNEL_VERSION`         | System kernel version                     |
-| `NETWORK_RX_{INTERFACE}` | Received KB/s from specified interface    |
-| `NETWORK_TX_{INTERFACE}` | Transmitted KB/s from specified interface |
+| `NETWORK_RX_{INTERFACE}` | Received KiB/s from specified interface   |
+| `NETWORK_TX_{INTERFACE}` | Transmitted KiB/s from specified interface |
 | `OS_VERSION`             | System OS version                         |
 | `LONG_OS_VERSION`        | System long OS version                    |
 | `RAM_TOTAL`              | Total memory GB                           |

--- a/README.md
+++ b/README.md
@@ -145,14 +145,14 @@ Add the `--verbose` flag to see more detailed output:
 ```console
 $ stats_provider --cpu usage --disk usage --memory ram_usage --interval 2 --verbose
 SketchyBar Stats Provider is running.
-Stats Provider CLI: Cli { all: false, cpu: Some(["usage"]), disk: Some(["usage"]), memory: Some(["ram_usage"]), network: None, system: None, interval: 2, bar: None, verbose: true }
-Successfully sent to SketchyBar: --add event system_stats
+Stats Provider CLI: Cli { all: false, battery: None, cpu: Some(["usage"]), disk: Some(["usage"]), memory: Some(["ram_usage"]), network: None, system: None, uptime: None, interval: 2, network_refresh_rate: 5, bar: None, verbose: true, no_units: false }
+Successfully sent to SketchyBar: (Bar: sketchybar): --add event system_stats
 Current message: CPU_USAGE="4%" DISK_USAGE="65%" RAM_USAGE="54%"
-Successfully sent to SketchyBar: --trigger system_stats CPU_USAGE="4%" DISK_USAGE="65%" RAM_USAGE="54%"
+Successfully sent to SketchyBar: (Bar: sketchybar): --trigger system_stats CPU_USAGE="4%" DISK_USAGE="65%" RAM_USAGE="54%"
 Current message: CPU_USAGE="6%" DISK_USAGE="65%" RAM_USAGE="54%"
-Successfully sent to SketchyBar: --trigger system_stats CPU_USAGE="6%" DISK_USAGE="65%" RAM_USAGE="54%"
+Successfully sent to SketchyBar: (Bar: sketchybar): --trigger system_stats CPU_USAGE="6%" DISK_USAGE="65%" RAM_USAGE="54%"
 Current message: CPU_USAGE="5%" DISK_USAGE="65%" RAM_USAGE="54%"
-Successfully sent to SketchyBar: --trigger system_stats CPU_USAGE="5%" DISK_USAGE="65%" RAM_USAGE="54%"
+Successfully sent to SketchyBar: (Bar: sketchybar): --trigger system_stats CPU_USAGE="5%" DISK_USAGE="65%" RAM_USAGE="54%"
 ```
 
 ## Usage with Sketchybar

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -210,61 +210,58 @@ mod tests {
     }
 
     #[test]
-    fn test_cli_parses_valid_bounds() {
-        let interval = DEFAULT_INTERVAL.to_string();
-        let rate = DEFAULT_NETWORK_REFRESH_RATE.to_string();
-
-        assert!(
-            Cli::try_parse_from([
-                "stats_provider",
-                "--all",
-                "--interval",
-                interval.as_str(),
-                "--network-refresh-rate",
-                rate.as_str(),
-            ])
-            .is_ok()
+    fn test_every_all_flag_round_trips_through_cli() {
+        type FlagCase = (
+            &'static str,
+            &'static [&'static str],
+            fn(&Cli) -> Option<&[String]>,
         );
+        let cases: [FlagCase; 6] = [
+            ("battery", ALL_BATTERY_FLAGS, |c| c.battery.as_deref()),
+            ("cpu", ALL_CPU_FLAGS, |c| c.cpu.as_deref()),
+            ("disk", ALL_DISK_FLAGS, |c| c.disk.as_deref()),
+            ("memory", ALL_MEMORY_FLAGS, |c| c.memory.as_deref()),
+            ("system", ALL_SYSTEM_FLAGS, |c| c.system.as_deref()),
+            ("uptime", ALL_UPTIME_FLAGS, |c| c.uptime.as_deref()),
+        ];
+
+        for (arg, flags, accessor) in cases {
+            // Every flag in the const slice round-trips through the CLI on its own.
+            for &flag in flags {
+                let flag_arg = format!("--{arg}");
+                let parsed = Cli::try_parse_from(["stats_provider", flag_arg.as_str(), flag])
+                    .expect("expected a known flag value to parse");
+                assert_eq!(accessor(&parsed), Some(&[flag.to_string()][..]));
+            }
+
+            // Passing every flag at once yields the full const slice.
+            let flag_arg = format!("--{arg}");
+            let mut all_args = vec!["stats_provider", flag_arg.as_str()];
+            all_args.extend(flags.iter().copied());
+            let parsed = Cli::try_parse_from(all_args).expect("expected all flags to parse");
+            let expected: Vec<String> = flags.iter().map(|s| s.to_string()).collect();
+            assert_eq!(accessor(&parsed), Some(expected.as_slice()));
+        }
     }
 
     #[test]
-    fn test_all_battery_flags_const_has_expected_values() {
-        assert_eq!(
-            ALL_BATTERY_FLAGS,
-            &["percentage", "remaining", "state", "time_to_full"]
-        );
+    fn test_unknown_flag_values_are_rejected() {
+        for arg in ["battery", "cpu", "disk", "memory", "system", "uptime"] {
+            let flag_arg = format!("--{arg}");
+            let result = Cli::try_parse_from(["stats_provider", flag_arg.as_str(), "bogus"]);
+            assert!(result.is_err(), "--{arg} should reject an unknown value");
+        }
     }
 
     #[test]
-    fn test_all_cpu_flags_const_has_expected_values() {
-        assert_eq!(
-            ALL_CPU_FLAGS,
-            &["count", "frequency", "temperature", "usage"]
-        );
-    }
+    fn test_interval_and_network_refresh_rate_defaults() {
+        let cli = Cli::try_parse_from(["stats_provider", "--all"]).unwrap();
 
-    #[test]
-    fn test_all_disk_flags_const_has_expected_values() {
-        assert_eq!(ALL_DISK_FLAGS, &["count", "free", "total", "usage", "used"]);
-    }
-
-    #[test]
-    fn test_all_memory_flags_const_contains_ram_and_swap() {
-        assert!(ALL_MEMORY_FLAGS.contains(&"ram_available"));
-        assert!(ALL_MEMORY_FLAGS.contains(&"swp_total"));
-        assert_eq!(ALL_MEMORY_FLAGS.len(), 8);
-    }
-
-    #[test]
-    fn test_all_system_flags_const_has_expected_values() {
-        assert!(ALL_SYSTEM_FLAGS.contains(&"arch"));
-        assert!(ALL_SYSTEM_FLAGS.contains(&"distro"));
-        assert_eq!(ALL_SYSTEM_FLAGS.len(), 7);
-    }
-
-    #[test]
-    fn test_all_uptime_flags_const_has_expected_values() {
-        assert_eq!(ALL_UPTIME_FLAGS, &["week", "day", "hour", "min", "sec"]);
+        assert_eq!(cli.interval, DEFAULT_INTERVAL);
+        assert_eq!(cli.network_refresh_rate, DEFAULT_NETWORK_REFRESH_RATE);
+        assert!((MIN_INTERVAL..=MAX_INTERVAL).contains(&cli.interval));
+        assert!(cli.network_refresh_rate >= MIN_NETWORK_REFRESH_RATE);
+        assert!(cli.network_refresh_rate <= MAX_NETWORK_REFRESH_RATE);
     }
 
     #[test]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -27,7 +27,7 @@ pub struct Cli {
     #[arg(short = 'm', long, num_args = 1.., value_parser = all_memory_flags(), help = "Get memory stats")]
     pub memory: Option<Vec<String>>,
 
-    #[arg(short = 'n', long, num_args = 1.., help = "Network rx/tx in KB/s. Specify network interfaces (e.g., -n eth0 en0 lo0). At least one is required.")]
+    #[arg(short = 'n', long, num_args = 1.., help = "Network rx/tx in KiB/s. Specify network interfaces (e.g., -n eth0 en0 lo0). At least one is required.")]
     pub network: Option<Vec<String>>,
 
     #[arg(short = 's', long, num_args = 1.., value_parser = all_system_flags(), help = "Get system stats")]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -9,55 +9,83 @@ pub const MAX_INTERVAL: u32 = 3600; // 1 hour max
 pub const MIN_NETWORK_REFRESH_RATE: u32 = 1;
 pub const MAX_NETWORK_REFRESH_RATE: u32 = 100;
 
+pub const ALL_BATTERY_FLAGS: &[&str] = &["percentage", "remaining", "state", "time_to_full"];
+pub const ALL_CPU_FLAGS: &[&str] = &["count", "frequency", "temperature", "usage"];
+pub const ALL_DISK_FLAGS: &[&str] = &["count", "free", "total", "usage", "used"];
+pub const ALL_RAM_FLAGS: &[&str] = &["ram_available", "ram_total", "ram_usage", "ram_used"];
+pub const ALL_SWP_FLAGS: &[&str] = &["swp_free", "swp_total", "swp_usage", "swp_used"];
+pub const ALL_MEMORY_FLAGS: &[&str] = &[
+    "ram_available",
+    "ram_total",
+    "ram_usage",
+    "ram_used",
+    "swp_free",
+    "swp_total",
+    "swp_usage",
+    "swp_used",
+];
+pub const ALL_SYSTEM_FLAGS: &[&str] = &[
+    "arch",
+    "distro",
+    "host_name",
+    "kernel_version",
+    "name",
+    "os_version",
+    "long_os_version",
+];
+pub const ALL_UPTIME_FLAGS: &[&str] = &["week", "day", "hour", "min", "sec"];
+
 #[derive(Parser, Debug)]
 #[command(name = "stats_provider", version, about, long_about = None, arg_required_else_help = true)]
 pub struct Cli {
-    #[arg(short = 'a', long, num_args = 0, help = "Get all stats")]
+    #[arg(short = 'a', long, help = "Get all stats")]
     pub all: bool,
 
-    #[arg(short = 'b', long, num_args = 1.., value_parser = all_battery_flags(), help = "Get battery stats")]
+    #[arg(short = 'b', long, num_args = 1.., value_parser = clap::builder::PossibleValuesParser::new(ALL_BATTERY_FLAGS), help = "Get battery stats")]
     pub battery: Option<Vec<String>>,
 
-    #[arg(short = 'c', long, num_args = 1.., value_parser = all_cpu_flags(), help = "Get CPU stats")]
+    #[arg(short = 'c', long, num_args = 1.., value_parser = clap::builder::PossibleValuesParser::new(ALL_CPU_FLAGS), help = "Get CPU stats")]
     pub cpu: Option<Vec<String>>,
 
-    #[arg(short = 'd', long, num_args = 1.., value_parser = all_disk_flags(), help = "Get disk stats")]
+    #[arg(short = 'd', long, num_args = 1.., value_parser = clap::builder::PossibleValuesParser::new(ALL_DISK_FLAGS), help = "Get disk stats")]
     pub disk: Option<Vec<String>>,
 
-    #[arg(short = 'm', long, num_args = 1.., value_parser = all_memory_flags(), help = "Get memory stats")]
+    #[arg(short = 'm', long, num_args = 1.., value_parser = clap::builder::PossibleValuesParser::new(ALL_MEMORY_FLAGS), help = "Get memory stats")]
     pub memory: Option<Vec<String>>,
 
     #[arg(short = 'n', long, num_args = 1.., help = "Network rx/tx in KiB/s. Specify network interfaces (e.g., -n eth0 en0 lo0). At least one is required.")]
     pub network: Option<Vec<String>>,
 
-    #[arg(short = 's', long, num_args = 1.., value_parser = all_system_flags(), help = "Get system stats")]
+    #[arg(short = 's', long, num_args = 1.., value_parser = clap::builder::PossibleValuesParser::new(ALL_SYSTEM_FLAGS), help = "Get system stats")]
     pub system: Option<Vec<String>>,
 
-    #[arg(short = 'u', long, num_args = 1.., value_parser = all_uptime_flags(), help = "Get uptime stats")]
+    #[arg(short = 'u', long, num_args = 1.., value_parser = clap::builder::PossibleValuesParser::new(ALL_UPTIME_FLAGS), help = "Get uptime stats")]
     pub uptime: Option<Vec<String>>,
 
     #[arg(
         short = 'i',
         long,
         default_value_t = DEFAULT_INTERVAL,
-        help = "Refresh interval in seconds"
+        value_parser = clap::value_parser!(u32).range((MIN_INTERVAL as i64)..=(MAX_INTERVAL as i64)),
+        help = "Refresh interval in seconds (1-3600)"
     )]
     pub interval: u32,
 
     #[arg(
         long,
         default_value_t = DEFAULT_NETWORK_REFRESH_RATE,
-        help = "Network refresh rate (how often to refresh network interface list, in stat intervals)"
+        value_parser = clap::value_parser!(u32).range((MIN_NETWORK_REFRESH_RATE as i64)..=(MAX_NETWORK_REFRESH_RATE as i64)),
+        help = "Network refresh rate (how often to refresh the network interface list, in stat intervals) (1-100)"
     )]
     pub network_refresh_rate: u32,
 
     #[arg(long, help = "Bar name (optional)")]
     pub bar: Option<String>,
 
-    #[arg(long, default_value_t = false, help = "Enable verbose output")]
+    #[arg(long, help = "Enable verbose output")]
     pub verbose: bool,
 
-    #[arg(long, default_value_t = false, help = "Output values without units")]
+    #[arg(long, help = "Output values without units")]
     pub no_units: bool,
 }
 
@@ -66,28 +94,6 @@ pub fn parse_args() -> Cli {
 }
 
 pub fn validate_cli(cli: &Cli) -> Result<()> {
-    // Validate interval
-    if cli.interval < MIN_INTERVAL || cli.interval > MAX_INTERVAL {
-        bail!(
-            "Interval must be between {} and {} seconds, got {}",
-            MIN_INTERVAL,
-            MAX_INTERVAL,
-            cli.interval
-        );
-    }
-
-    // Validate network refresh rate
-    if cli.network_refresh_rate < MIN_NETWORK_REFRESH_RATE
-        || cli.network_refresh_rate > MAX_NETWORK_REFRESH_RATE
-    {
-        bail!(
-            "Network refresh rate must be between {} and {}, got {}",
-            MIN_NETWORK_REFRESH_RATE,
-            MAX_NETWORK_REFRESH_RATE,
-            cli.network_refresh_rate
-        );
-    }
-
     // Validate that at least one stat type is requested if not using --all
     if !cli.all
         && cli.battery.is_none()
@@ -102,49 +108,6 @@ pub fn validate_cli(cli: &Cli) -> Result<()> {
     }
 
     Ok(())
-}
-
-pub fn all_battery_flags() -> Vec<&'static str> {
-    vec!["percentage", "remaining", "state", "time_to_full"]
-}
-
-pub fn all_cpu_flags() -> Vec<&'static str> {
-    vec!["count", "frequency", "temperature", "usage"]
-}
-
-pub fn all_disk_flags() -> Vec<&'static str> {
-    vec!["count", "free", "total", "usage", "used"]
-}
-
-pub fn all_ram_flags() -> Vec<&'static str> {
-    vec!["ram_available", "ram_total", "ram_usage", "ram_used"]
-}
-
-pub fn all_swp_flags() -> Vec<&'static str> {
-    vec!["swp_free", "swp_total", "swp_usage", "swp_used"]
-}
-
-pub fn all_memory_flags() -> Vec<&'static str> {
-    let mut flags = Vec::new();
-    flags.extend(all_ram_flags());
-    flags.extend(all_swp_flags());
-    flags
-}
-
-pub fn all_system_flags() -> Vec<&'static str> {
-    vec![
-        "arch",
-        "distro",
-        "host_name",
-        "kernel_version",
-        "name",
-        "os_version",
-        "long_os_version",
-    ]
-}
-
-pub fn all_uptime_flags() -> Vec<&'static str> {
-    vec!["week", "day", "hour", "min", "sec"]
 }
 
 #[cfg(test)]
@@ -212,116 +175,101 @@ mod tests {
     }
 
     #[test]
-    fn test_validate_cli_interval_too_low() {
-        let cli = Cli {
-            all: true,
-            battery: None,
-            cpu: None,
-            disk: None,
-            memory: None,
-            network: None,
-            system: None,
-            uptime: None,
-            interval: 0,
-            network_refresh_rate: DEFAULT_NETWORK_REFRESH_RATE,
-            bar: None,
-            verbose: false,
-            no_units: false,
-        };
-        assert!(validate_cli(&cli).is_err());
+    fn test_interval_range_validation_via_clap() {
+        let min = MIN_INTERVAL.to_string();
+        let max = MAX_INTERVAL.to_string();
+        let max_plus_one = (MAX_INTERVAL + 1).to_string();
+
+        assert!(Cli::try_parse_from(["stats_provider", "-i", min.as_str()]).is_ok());
+        assert!(Cli::try_parse_from(["stats_provider", "-i", max.as_str()]).is_ok());
+        assert!(Cli::try_parse_from(["stats_provider", "-i", "0"]).is_err());
+        assert!(Cli::try_parse_from(["stats_provider", "-i", max_plus_one.as_str()]).is_err());
     }
 
     #[test]
-    fn test_validate_cli_interval_too_high() {
-        let cli = Cli {
-            all: true,
-            battery: None,
-            cpu: None,
-            disk: None,
-            memory: None,
-            network: None,
-            system: None,
-            uptime: None,
-            interval: MAX_INTERVAL + 1,
-            network_refresh_rate: DEFAULT_NETWORK_REFRESH_RATE,
-            bar: None,
-            verbose: false,
-            no_units: false,
-        };
-        assert!(validate_cli(&cli).is_err());
+    fn test_network_refresh_rate_range_validation_via_clap() {
+        let min = MIN_NETWORK_REFRESH_RATE.to_string();
+        let max = MAX_NETWORK_REFRESH_RATE.to_string();
+        let max_plus_one = (MAX_NETWORK_REFRESH_RATE + 1).to_string();
+
+        assert!(
+            Cli::try_parse_from(["stats_provider", "--network-refresh-rate", min.as_str()]).is_ok()
+        );
+        assert!(
+            Cli::try_parse_from(["stats_provider", "--network-refresh-rate", max.as_str()]).is_ok()
+        );
+        assert!(Cli::try_parse_from(["stats_provider", "--network-refresh-rate", "0"]).is_err());
+        assert!(
+            Cli::try_parse_from([
+                "stats_provider",
+                "--network-refresh-rate",
+                max_plus_one.as_str()
+            ])
+            .is_err()
+        );
     }
 
     #[test]
-    fn test_validate_cli_network_refresh_rate_too_low() {
-        let cli = Cli {
-            all: true,
-            battery: None,
-            cpu: None,
-            disk: None,
-            memory: None,
-            network: None,
-            system: None,
-            uptime: None,
-            interval: DEFAULT_INTERVAL,
-            network_refresh_rate: 0,
-            bar: None,
-            verbose: false,
-            no_units: false,
-        };
-        assert!(validate_cli(&cli).is_err());
+    fn test_cli_parses_valid_bounds() {
+        let interval = DEFAULT_INTERVAL.to_string();
+        let rate = DEFAULT_NETWORK_REFRESH_RATE.to_string();
+
+        assert!(
+            Cli::try_parse_from([
+                "stats_provider",
+                "--all",
+                "--interval",
+                interval.as_str(),
+                "--network-refresh-rate",
+                rate.as_str(),
+            ])
+            .is_ok()
+        );
     }
 
     #[test]
-    fn test_validate_cli_network_refresh_rate_too_high() {
-        let cli = Cli {
-            all: true,
-            battery: None,
-            cpu: None,
-            disk: None,
-            memory: None,
-            network: None,
-            system: None,
-            uptime: None,
-            interval: DEFAULT_INTERVAL,
-            network_refresh_rate: MAX_NETWORK_REFRESH_RATE + 1,
-            bar: None,
-            verbose: false,
-            no_units: false,
-        };
-        assert!(validate_cli(&cli).is_err());
+    fn test_all_battery_flags_const_has_expected_values() {
+        assert_eq!(
+            ALL_BATTERY_FLAGS,
+            &["percentage", "remaining", "state", "time_to_full"]
+        );
     }
 
     #[test]
-    fn test_all_cpu_flags_returns_correct_flags() {
-        let flags = all_cpu_flags();
-        assert_eq!(flags, vec!["count", "frequency", "temperature", "usage"]);
+    fn test_all_cpu_flags_const_has_expected_values() {
+        assert_eq!(
+            ALL_CPU_FLAGS,
+            &["count", "frequency", "temperature", "usage"]
+        );
     }
 
     #[test]
-    fn test_all_disk_flags_returns_correct_flags() {
-        let flags = all_disk_flags();
-        assert_eq!(flags, vec!["count", "free", "total", "usage", "used"]);
+    fn test_all_disk_flags_const_has_expected_values() {
+        assert_eq!(ALL_DISK_FLAGS, &["count", "free", "total", "usage", "used"]);
     }
 
     #[test]
-    fn test_all_memory_flags_contains_ram_and_swap() {
-        let flags = all_memory_flags();
-        assert!(flags.contains(&"ram_available"));
-        assert!(flags.contains(&"swp_total"));
-        assert_eq!(flags.len(), 8);
+    fn test_all_memory_flags_const_contains_ram_and_swap() {
+        assert!(ALL_MEMORY_FLAGS.contains(&"ram_available"));
+        assert!(ALL_MEMORY_FLAGS.contains(&"swp_total"));
+        assert_eq!(ALL_MEMORY_FLAGS.len(), 8);
     }
 
     #[test]
-    fn test_all_system_flags_returns_correct_flags() {
-        let flags = all_system_flags();
-        assert!(flags.contains(&"arch"));
-        assert!(flags.contains(&"distro"));
-        assert_eq!(flags.len(), 7);
+    fn test_all_system_flags_const_has_expected_values() {
+        assert!(ALL_SYSTEM_FLAGS.contains(&"arch"));
+        assert!(ALL_SYSTEM_FLAGS.contains(&"distro"));
+        assert_eq!(ALL_SYSTEM_FLAGS.len(), 7);
     }
 
     #[test]
-    fn test_all_uptime_flags_returns_correct_flags() {
-        let flags = all_uptime_flags();
-        assert_eq!(flags, vec!["week", "day", "hour", "min", "sec"]);
+    fn test_all_uptime_flags_const_has_expected_values() {
+        assert_eq!(ALL_UPTIME_FLAGS, &["week", "day", "hour", "min", "sec"]);
+    }
+
+    #[test]
+    fn test_cli_command_debug_assert() {
+        use clap::CommandFactory;
+        Cli::command().debug_assert();
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -411,4 +411,155 @@ mod tests {
 
         assert!(result.is_err());
     }
+
+    #[test]
+    fn test_collect_stats_commands_all_dispatch_emits_every_flag() {
+        let cli = cli::Cli {
+            all: true,
+            battery: None,
+            cpu: None,
+            disk: None,
+            memory: None,
+            network: None,
+            system: None,
+            uptime: None,
+            interval: 5,
+            network_refresh_rate: 5,
+            bar: None,
+            verbose: false,
+            no_units: false,
+        };
+        let flags = process_cli_flags(&cli);
+        let config = StatsConfig {
+            flags,
+            refresh_kind: stats::build_refresh_kind(),
+        };
+        let mut system = System::new_with_specifics(stats::build_refresh_kind());
+        let mut disks = Disks::new_with_refreshed_list();
+        let mut networks = Networks::new_with_refreshed_list();
+        let mut components = Components::new_with_refreshed_list();
+        let mut context = StatsContext {
+            system: &mut system,
+            disks: &mut disks,
+            networks: &mut networks,
+            components: &mut components,
+            network_baselines: NetworkRateBaselines::default(),
+        };
+        let mut buf = String::new();
+
+        let updated_tick =
+            collect_stats_commands(&cli, &config, &mut context, 0, &mut buf).unwrap();
+
+        for key in ["CPU_COUNT=", "CPU_FREQUENCY=", "CPU_TEMP=", "CPU_USAGE="] {
+            assert!(buf.contains(key), "missing CPU key {key} in: {buf}");
+        }
+        for key in [
+            "DISK_COUNT=",
+            "DISK_FREE=",
+            "DISK_TOTAL=",
+            "DISK_USED=",
+            "DISK_USAGE=",
+        ] {
+            assert!(buf.contains(key), "missing disk key {key} in: {buf}");
+        }
+        for key in [
+            "RAM_AVAILABLE=",
+            "RAM_TOTAL=",
+            "RAM_USED=",
+            "RAM_USAGE=",
+            "SWP_FREE=",
+            "SWP_TOTAL=",
+            "SWP_USED=",
+            "SWP_USAGE=",
+        ] {
+            assert!(buf.contains(key), "missing memory key {key} in: {buf}");
+        }
+        assert!(buf.contains("UPTIME=\""), "missing uptime in: {buf}");
+        assert!(buf.contains("NETWORK_RX_"), "missing network rx in: {buf}");
+        assert!(buf.contains("NETWORK_TX_"), "missing network tx in: {buf}");
+
+        // System stats are startup-only (send_initial_system_stats), so the
+        // per-tick buffer must not contain any system keys even with --all.
+        // Keys carry the opening quote to avoid substring collisions with
+        // e.g. a NETWORK_RX_SYSTEM_NAME= key.
+        for key in [
+            "ARCH=\"",
+            "DISTRO=\"",
+            "HOST_NAME=\"",
+            "KERNEL_VERSION=\"",
+            "SYSTEM_NAME=\"",
+            "OS_VERSION=\"",
+            "LONG_OS_VERSION=\"",
+        ] {
+            assert!(
+                !buf.contains(key),
+                "system key {key} leaked into per-tick buffer: {buf}"
+            );
+        }
+
+        // Battery is hardware-dependent: percentage and state are always
+        // emitted together when a battery exists, otherwise the machine is
+        // battery-less and no battery keys appear.
+        if buf.contains("BATTERY_PERCENTAGE=") {
+            assert!(
+                buf.contains("BATTERY_STATE="),
+                "battery state missing in: {buf}"
+            );
+        }
+
+        assert_eq!(
+            updated_tick, 1,
+            "tick 0 + 1 below refresh rate 5, got {updated_tick}"
+        );
+    }
+
+    #[test]
+    fn test_collect_stats_commands_network_refresh_tick_wraps() {
+        let cli = cli::Cli {
+            all: true,
+            battery: None,
+            cpu: None,
+            disk: None,
+            memory: None,
+            network: None,
+            system: None,
+            uptime: None,
+            interval: 5,
+            network_refresh_rate: 5,
+            bar: None,
+            verbose: false,
+            no_units: false,
+        };
+        let flags = process_cli_flags(&cli);
+        let config = StatsConfig {
+            flags,
+            refresh_kind: stats::build_refresh_kind(),
+        };
+        let mut system = System::new_with_specifics(stats::build_refresh_kind());
+        let mut disks = Disks::new_with_refreshed_list();
+        let mut networks = Networks::new_with_refreshed_list();
+        let mut components = Components::new_with_refreshed_list();
+        let mut context = StatsContext {
+            system: &mut system,
+            disks: &mut disks,
+            networks: &mut networks,
+            components: &mut components,
+            network_baselines: NetworkRateBaselines::default(),
+        };
+        let mut buf = String::new();
+
+        // tick 4 + 1 == refresh rate 5: re-list the interfaces and reset to 0.
+        let wrapped = collect_stats_commands(&cli, &config, &mut context, 4, &mut buf).unwrap();
+        assert_eq!(
+            wrapped, 0,
+            "tick at refresh rate - 1 should wrap to 0, got {wrapped}"
+        );
+
+        // tick 0 + 1 < refresh rate 5: just increment.
+        let incremented = collect_stats_commands(&cli, &config, &mut context, 0, &mut buf).unwrap();
+        assert_eq!(
+            incremented, 1,
+            "tick below refresh rate should increment, got {incremented}"
+        );
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,8 @@ use anyhow::{Context, Result};
 use fs2::FileExt;
 use sketchybar::Sketchybar;
 use stats::{
-    get_battery_stats, get_cpu_stats, get_disk_stats, get_memory_stats, get_network_stats,
-    get_system_stats, get_uptime_stats,
+    NetworkRateBaselines, get_battery_stats, get_cpu_stats, get_disk_stats, get_memory_stats,
+    get_network_stats, get_system_stats, get_uptime_stats,
 };
 use sysinfo::{Components, Disks, Networks, System};
 
@@ -43,7 +43,8 @@ struct StatsContext<'a> {
     system: &'a mut System,
     disks: &'a mut Disks,
     networks: &'a mut Networks,
-    components: &'a Components,
+    components: &'a mut Components,
+    network_baselines: NetworkRateBaselines,
 }
 
 struct StatsConfig<'a> {
@@ -118,7 +119,7 @@ async fn get_stats(cli: &cli::Cli, sketchybar: &Sketchybar) -> Result<()> {
     let mut system = System::new_with_specifics(refresh_kind);
     let mut disks = Disks::new_with_refreshed_list();
     let mut networks = Networks::new_with_refreshed_list();
-    let components = Components::new_with_refreshed_list();
+    let mut components = Components::new_with_refreshed_list();
 
     if let Some(network_flags) = &cli.network {
         validate_network_interfaces(&networks, network_flags, cli.verbose)?;
@@ -145,7 +146,8 @@ async fn get_stats(cli: &cli::Cli, sketchybar: &Sketchybar) -> Result<()> {
         system: &mut system,
         disks: &mut disks,
         networks: &mut networks,
-        components: &components,
+        components: &mut components,
+        network_baselines: NetworkRateBaselines::default(),
     };
 
     run_stats_loop(cli, sketchybar, &config, &mut context, &mut message_buffer).await
@@ -216,6 +218,7 @@ fn collect_stats_commands(
 
     context.system.refresh_specifics(config.refresh_kind);
     context.disks.refresh(true);
+    context.components.refresh(false);
 
     let mut updated_tick = network_refresh_tick + 1;
     if updated_tick >= cli.network_refresh_rate {
@@ -225,55 +228,70 @@ fn collect_stats_commands(
         context.networks.refresh(true);
     }
 
-    if cli.all {
-        get_battery_stats(&cli::all_battery_flags(), cli.no_units, buf);
+    let battery_flags: Option<Vec<&str>> = if cli.all {
+        Some(cli::all_battery_flags())
+    } else {
+        config.flags.battery_flag_refs()
+    };
+    if let Some(battery_flags) = battery_flags {
+        get_battery_stats(&battery_flags, cli.no_units, buf);
+    }
+
+    let cpu_flags: Option<Vec<&str>> = if cli.all {
+        Some(cli::all_cpu_flags())
+    } else {
+        config.flags.cpu_flag_refs()
+    };
+    if let Some(cpu_flags) = cpu_flags {
         get_cpu_stats(
             context.system,
             context.components,
-            &cli::all_cpu_flags(),
+            &cpu_flags,
             cli.no_units,
             buf,
         );
-        get_disk_stats(context.disks, &cli::all_disk_flags(), cli.no_units, buf);
-        get_memory_stats(context.system, &cli::all_memory_flags(), cli.no_units, buf);
-        get_network_stats(context.networks, None, cli.interval, cli.no_units, buf);
-        get_uptime_stats(&cli::all_uptime_flags(), buf);
+    }
+
+    let disk_flags: Option<Vec<&str>> = if cli.all {
+        Some(cli::all_disk_flags())
     } else {
-        if let Some(battery_flag_refs) = config.flags.battery_flag_refs() {
-            get_battery_stats(&battery_flag_refs, cli.no_units, buf);
-        }
+        config.flags.disk_flag_refs()
+    };
+    if let Some(disk_flags) = disk_flags {
+        get_disk_stats(context.disks, &disk_flags, cli.no_units, buf);
+    }
 
-        if let Some(cpu_flag_refs) = config.flags.cpu_flag_refs() {
-            get_cpu_stats(
-                context.system,
-                context.components,
-                &cpu_flag_refs,
-                cli.no_units,
-                buf,
-            );
-        }
+    let memory_flags: Option<Vec<&str>> = if cli.all {
+        Some(cli::all_memory_flags())
+    } else {
+        config.flags.memory_flag_refs()
+    };
+    if let Some(memory_flags) = memory_flags {
+        get_memory_stats(context.system, &memory_flags, cli.no_units, buf);
+    }
 
-        if let Some(disk_flag_refs) = config.flags.disk_flag_refs() {
-            get_disk_stats(context.disks, &disk_flag_refs, cli.no_units, buf);
-        }
+    let network_interfaces: Option<&[String]> = if cli.all {
+        None
+    } else {
+        config.flags.network_flags
+    };
+    if cli.all || network_interfaces.is_some() {
+        get_network_stats(
+            context.networks,
+            network_interfaces,
+            &mut context.network_baselines,
+            cli.no_units,
+            buf,
+        );
+    }
 
-        if let Some(memory_flag_refs) = config.flags.memory_flag_refs() {
-            get_memory_stats(context.system, &memory_flag_refs, cli.no_units, buf);
-        }
-
-        if let Some(network_flags) = config.flags.network_flags {
-            get_network_stats(
-                context.networks,
-                Some(network_flags),
-                cli.interval,
-                cli.no_units,
-                buf,
-            );
-        }
-
-        if let Some(uptime_flag_refs) = config.flags.uptime_flag_refs() {
-            get_uptime_stats(&uptime_flag_refs, buf);
-        }
+    let uptime_flags: Option<Vec<&str>> = if cli.all {
+        Some(cli::all_uptime_flags())
+    } else {
+        config.flags.uptime_flag_refs()
+    };
+    if let Some(uptime_flags) = uptime_flags {
+        get_uptime_stats(&uptime_flags, buf);
     }
 
     Ok(updated_tick)
@@ -292,7 +310,10 @@ async fn main() -> Result<()> {
 
     let _lock = match acquire_lock() {
         Some(lock) => lock,
-        None => return Ok(()),
+        None => {
+            eprintln!("another stats_provider instance is already running; exiting");
+            return Ok(());
+        }
     };
 
     cli::validate_cli(&cli).context("Invalid CLI arguments")?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -297,8 +297,13 @@ fn collect_stats_commands(
     Ok(updated_tick)
 }
 
+fn lock_file_path() -> std::path::PathBuf {
+    std::env::temp_dir().join("stats_provider.lock")
+}
+
 fn acquire_lock() -> Option<File> {
-    let file = File::create("/tmp/stats_provider.lock").ok()?;
+    let path = lock_file_path();
+    let file = File::create(path).ok()?;
     file.try_lock_exclusive().ok()?;
     Some(file)
 }
@@ -338,6 +343,19 @@ async fn main() -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_acquire_lock_prevents_second_instance() {
+        // Host-state-independent: passes whether or not a real instance already
+        // holds the lock, but fails if exclusive locking is removed (both opens
+        // would then succeed).
+        let first = acquire_lock();
+        let second = acquire_lock();
+        assert!(
+            !(first.is_some() && second.is_some()),
+            "two concurrent instances should never both acquire the lock"
+        );
+    }
 
     #[test]
     fn test_process_cli_flags() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -401,4 +401,14 @@ mod tests {
         assert!(flags.memory_flag_refs().is_none());
         assert!(flags.uptime_flag_refs().is_none());
     }
+
+    #[test]
+    fn test_validate_network_interfaces_rejects_unknown() {
+        let networks = Networks::new_with_refreshed_list();
+        let requested = vec!["definitely-not-an-interface-xyz".to_string()];
+
+        let result = validate_network_interfaces(&networks, &requested, false);
+
+        assert!(result.is_err());
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -102,7 +102,7 @@ async fn send_initial_system_stats(
         system.refresh_specifics(*refresh_kind);
         let system_flags = match &cli.system {
             Some(flags) => flags.iter().map(|s| s.as_str()).collect::<Vec<&str>>(),
-            None => cli::all_system_flags(),
+            None => cli::ALL_SYSTEM_FLAGS.to_vec(),
         };
         buf.clear();
         get_system_stats(&system_flags, buf);
@@ -229,7 +229,7 @@ fn collect_stats_commands(
     }
 
     let battery_flags: Option<Vec<&str>> = if cli.all {
-        Some(cli::all_battery_flags())
+        Some(cli::ALL_BATTERY_FLAGS.to_vec())
     } else {
         config.flags.battery_flag_refs()
     };
@@ -238,7 +238,7 @@ fn collect_stats_commands(
     }
 
     let cpu_flags: Option<Vec<&str>> = if cli.all {
-        Some(cli::all_cpu_flags())
+        Some(cli::ALL_CPU_FLAGS.to_vec())
     } else {
         config.flags.cpu_flag_refs()
     };
@@ -253,7 +253,7 @@ fn collect_stats_commands(
     }
 
     let disk_flags: Option<Vec<&str>> = if cli.all {
-        Some(cli::all_disk_flags())
+        Some(cli::ALL_DISK_FLAGS.to_vec())
     } else {
         config.flags.disk_flag_refs()
     };
@@ -262,7 +262,7 @@ fn collect_stats_commands(
     }
 
     let memory_flags: Option<Vec<&str>> = if cli.all {
-        Some(cli::all_memory_flags())
+        Some(cli::ALL_MEMORY_FLAGS.to_vec())
     } else {
         config.flags.memory_flag_refs()
     };
@@ -286,7 +286,7 @@ fn collect_stats_commands(
     }
 
     let uptime_flags: Option<Vec<&str>> = if cli.all {
-        Some(cli::all_uptime_flags())
+        Some(cli::ALL_UPTIME_FLAGS.to_vec())
     } else {
         config.flags.uptime_flag_refs()
     };

--- a/src/sketchybar.rs
+++ b/src/sketchybar.rs
@@ -104,7 +104,7 @@ impl Sketchybar {
         if verbose {
             println!(
                 "Successfully sent to SketchyBar: (Bar: {}): --{} {} {}",
-                self.bar_name.to_str().unwrap(),
+                self.bar_name.to_str().unwrap_or("?"),
                 flag,
                 event,
                 payload.unwrap_or_default()

--- a/src/stats/battery.rs
+++ b/src/stats/battery.rs
@@ -86,10 +86,4 @@ mod tests {
 
         assert_eq!(buf, "");
     }
-
-    #[test]
-    fn test_get_battery_stats_handles_no_battery() {
-        let mut buf = String::new();
-        get_battery_stats(&["percentage"], false, &mut buf);
-    }
 }

--- a/src/stats/battery.rs
+++ b/src/stats/battery.rs
@@ -1,3 +1,4 @@
+use super::{PERCENT, SECONDS_PER_MINUTE, unit};
 use starship_battery::{Manager, State};
 use std::fmt::Write;
 
@@ -21,8 +22,8 @@ pub fn get_battery_stats(flags: &[&str], no_units: bool, buf: &mut String) {
     for &flag in flags {
         match flag {
             "percentage" => {
-                let percentage = (battery.state_of_charge().value * 100.0).round() as u32;
-                let unit = if no_units { "" } else { "%" };
+                let percentage = (battery.state_of_charge().value * PERCENT).round() as u32;
+                let unit = unit(no_units, "%");
                 let _ = write!(buf, "BATTERY_PERCENTAGE=\"{percentage}{unit}\" ");
             }
             "state" => {
@@ -37,15 +38,15 @@ pub fn get_battery_stats(flags: &[&str], no_units: bool, buf: &mut String) {
             }
             "remaining" => {
                 if let Some(time) = battery.time_to_empty() {
-                    let mins = time.value as u32 / 60;
-                    let unit = if no_units { "" } else { "min" };
+                    let mins = time.value as u64 / SECONDS_PER_MINUTE;
+                    let unit = unit(no_units, "min");
                     let _ = write!(buf, "BATTERY_REMAINING=\"{mins}{unit}\" ");
                 }
             }
             "time_to_full" => {
                 if let Some(time) = battery.time_to_full() {
-                    let mins = time.value as u32 / 60;
-                    let unit = if no_units { "" } else { "min" };
+                    let mins = time.value as u64 / SECONDS_PER_MINUTE;
+                    let unit = unit(no_units, "min");
                     let _ = write!(buf, "BATTERY_TIME_TO_FULL=\"{mins}{unit}\" ");
                 }
             }

--- a/src/stats/battery.rs
+++ b/src/stats/battery.rs
@@ -65,7 +65,19 @@ mod tests {
         get_battery_stats(&["percentage", "state"], false, &mut buf);
 
         if !buf.is_empty() {
-            assert!(buf.contains("BATTERY_PERCENTAGE=") || buf.contains("BATTERY_STATE="));
+            assert!(buf.contains("BATTERY_PERCENTAGE="));
+            assert!(buf.contains("BATTERY_STATE="));
+            let value_start = buf
+                .find("BATTERY_PERCENTAGE=\"")
+                .expect("percentage key present")
+                + "BATTERY_PERCENTAGE=\"".len();
+            assert!(
+                buf[value_start..]
+                    .chars()
+                    .next()
+                    .is_some_and(|c| c.is_ascii_digit()),
+                "percentage value must be numeric"
+            );
         }
     }
 

--- a/src/stats/constants.rs
+++ b/src/stats/constants.rs
@@ -1,0 +1,38 @@
+/// Bytes in one gibibyte (1024^3), used to convert byte counts to gigabytes.
+pub const BYTES_PER_GB: f32 = 1_073_741_824.0;
+
+/// Bytes in one kibibyte (1024), used to convert byte counts to kibibytes.
+pub const BYTES_PER_KB: u64 = 1024;
+
+/// Factor used to scale a ratio in 0 to 1 into a percentage.
+pub const PERCENT: f32 = 100.0;
+
+/// Seconds in one minute, used for battery time conversions.
+pub const SECONDS_PER_MINUTE: u64 = 60;
+
+/// Temperature sentinel returned when no CPU temperature component is found.
+pub const NO_TEMP_SENTINEL: f32 = -1.0;
+
+/// Returns the unit string, or an empty string when units are disabled.
+pub fn unit(no_units: bool, unit: &'static str) -> &'static str {
+    if no_units { "" } else { unit }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_unit_with_units() {
+        assert_eq!(unit(false, "GB"), "GB");
+        assert_eq!(unit(false, "%"), "%");
+        assert_eq!(unit(false, "KiB/s"), "KiB/s");
+    }
+
+    #[test]
+    fn test_unit_without_units() {
+        assert_eq!(unit(true, "GB"), "");
+        assert_eq!(unit(true, "%"), "");
+        assert_eq!(unit(true, "KiB/s"), "");
+    }
+}

--- a/src/stats/cpu.rs
+++ b/src/stats/cpu.rs
@@ -74,30 +74,29 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_cpu_stats_with_units() {
+    fn test_get_cpu_stats_all_flags_emit_expected_keys() {
+        use crate::cli;
+
         let mut s = System::new_all();
         s.refresh_all();
         let components = Components::new_with_refreshed_list();
         let mut buf = String::new();
 
-        get_cpu_stats(&s, &components, &["count", "usage"], false, &mut buf);
+        get_cpu_stats(&s, &components, cli::ALL_CPU_FLAGS, false, &mut buf);
 
         assert!(buf.contains("CPU_COUNT="));
+        assert!(buf.contains("CPU_FREQUENCY="));
+        assert!(buf.contains("CPU_TEMP="));
         assert!(buf.contains("CPU_USAGE="));
         assert!(buf.contains("%"));
-    }
 
-    #[test]
-    fn test_get_cpu_stats_without_units() {
-        let mut s = System::new_all();
-        s.refresh_all();
-        let components = Components::new_with_refreshed_list();
-        let mut buf = String::new();
+        let mut no_units_buf = String::new();
+        get_cpu_stats(&s, &components, cli::ALL_CPU_FLAGS, true, &mut no_units_buf);
 
-        get_cpu_stats(&s, &components, &["usage"], true, &mut buf);
-
-        assert!(buf.contains("CPU_USAGE="));
-        assert!(!buf.contains("%"));
+        assert!(no_units_buf.contains("CPU_USAGE="));
+        assert!(!no_units_buf.contains("%"));
+        assert!(!no_units_buf.contains("MHz"));
+        assert!(!no_units_buf.contains("°C"));
     }
 
     #[test]

--- a/src/stats/cpu.rs
+++ b/src/stats/cpu.rs
@@ -1,3 +1,4 @@
+use super::{NO_TEMP_SENTINEL, unit};
 use std::fmt::Write;
 use sysinfo::{Components, System};
 
@@ -22,7 +23,7 @@ pub fn get_cpu_stats(
             "frequency" => {
                 let total_frequency: u64 = s.cpus().iter().map(|cpu| cpu.frequency()).sum();
                 let avg_freq = total_frequency / cpu_count as u64;
-                let unit = if no_units { "" } else { "MHz" };
+                let unit = unit(no_units, "MHz");
                 let _ = write!(buf, "CPU_FREQUENCY=\"{avg_freq}{unit}\" ");
             }
             "temperature" => {
@@ -45,18 +46,18 @@ pub fn get_cpu_stats(
                 let average_temp = if count > 0 {
                     total_temp / count as f32
                 } else {
-                    -1.0
+                    NO_TEMP_SENTINEL
                 };
 
-                let unit = if no_units { "" } else { "°C" };
-                if average_temp != -1.0 {
+                let unit = unit(no_units, "°C");
+                if average_temp != NO_TEMP_SENTINEL {
                     let _ = write!(buf, "CPU_TEMP=\"{average_temp:.1}{unit}\" ");
                 } else {
                     let _ = write!(buf, "CPU_TEMP=\"N/A{unit}\" ");
                 }
             }
             "usage" => {
-                let unit = if no_units { "" } else { "%" };
+                let unit = unit(no_units, "%");
                 let _ = write!(
                     buf,
                     "CPU_USAGE=\"{:.0}{unit}\" ",

--- a/src/stats/disk.rs
+++ b/src/stats/disk.rs
@@ -1,7 +1,6 @@
+use super::{BYTES_PER_GB, PERCENT, unit};
 use std::fmt::Write;
 use sysinfo::Disks;
-
-const BYTES_PER_GB: f32 = 1_073_741_824.0;
 
 pub fn get_disk_stats(disks: &Disks, flags: &[&str], no_units: bool, buf: &mut String) {
     let (total_space, used_space) = disks.list().iter().fold((0, 0), |(total, used), disk| {
@@ -11,7 +10,7 @@ pub fn get_disk_stats(disks: &Disks, flags: &[&str], no_units: bool, buf: &mut S
         )
     });
     let disk_usage_percentage = if total_space > 0 {
-        ((used_space as f32 / total_space as f32) * 100.0).round() as u32
+        ((used_space as f32 / total_space as f32) * PERCENT).round() as u32
     } else {
         0
     };
@@ -22,7 +21,7 @@ pub fn get_disk_stats(disks: &Disks, flags: &[&str], no_units: bool, buf: &mut S
                 let _ = write!(buf, "DISK_COUNT=\"{}\" ", disks.list().len());
             }
             "free" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "DISK_FREE=\"{:.1}{unit}\" ",
@@ -30,7 +29,7 @@ pub fn get_disk_stats(disks: &Disks, flags: &[&str], no_units: bool, buf: &mut S
                 );
             }
             "total" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "DISK_TOTAL=\"{:.1}{unit}\" ",
@@ -38,7 +37,7 @@ pub fn get_disk_stats(disks: &Disks, flags: &[&str], no_units: bool, buf: &mut S
                 );
             }
             "used" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "DISK_USED=\"{:.1}{unit}\" ",
@@ -46,7 +45,7 @@ pub fn get_disk_stats(disks: &Disks, flags: &[&str], no_units: bool, buf: &mut S
                 );
             }
             "usage" => {
-                let unit = if no_units { "" } else { "%" };
+                let unit = unit(no_units, "%");
                 let _ = write!(buf, "DISK_USAGE=\"{disk_usage_percentage}{unit}\" ");
             }
             _ => {}

--- a/src/stats/disk.rs
+++ b/src/stats/disk.rs
@@ -58,17 +58,33 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_disk_stats_with_units() {
+    fn test_get_disk_stats_all_flags_emit_expected_keys() {
+        use crate::cli;
+
         let disks = Disks::new_with_refreshed_list();
         let mut buf = String::new();
 
-        get_disk_stats(&disks, &["count", "total"], false, &mut buf);
+        get_disk_stats(&disks, cli::ALL_DISK_FLAGS, false, &mut buf);
 
         assert!(buf.contains("DISK_COUNT="));
+        assert!(buf.contains("DISK_FREE="));
+        assert!(buf.contains("DISK_TOTAL="));
+        assert!(buf.contains("DISK_USED="));
+        assert!(buf.contains("DISK_USAGE="));
     }
 
     #[test]
-    fn test_get_disk_stats_without_units() {
+    fn test_get_disk_stats_unknown_flag_ignored() {
+        let disks = Disks::new_with_refreshed_list();
+        let mut buf = String::new();
+
+        get_disk_stats(&disks, &["bogus"], false, &mut buf);
+
+        assert_eq!(buf, "");
+    }
+
+    #[test]
+    fn test_get_disk_stats_no_units() {
         let disks = Disks::new_with_refreshed_list();
         let mut buf = String::new();
 

--- a/src/stats/memory.rs
+++ b/src/stats/memory.rs
@@ -100,39 +100,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_memory_stats_with_units() {
+    fn test_get_memory_stats_all_flags_emit_expected_keys() {
         let mut s = System::new_all();
         s.refresh_all();
         let mut buf = String::new();
 
-        get_memory_stats(&s, &["ram_total", "ram_usage"], false, &mut buf);
+        get_memory_stats(&s, cli::ALL_MEMORY_FLAGS, false, &mut buf);
 
+        assert!(buf.contains("RAM_AVAILABLE="));
         assert!(buf.contains("RAM_TOTAL="));
+        assert!(buf.contains("RAM_USED="));
         assert!(buf.contains("RAM_USAGE="));
-        assert!(buf.contains("GB") || buf.contains("%"));
-    }
-
-    #[test]
-    fn test_get_memory_stats_without_units() {
-        let mut s = System::new_all();
-        s.refresh_all();
-        let mut buf = String::new();
-
-        get_memory_stats(&s, &["ram_usage"], true, &mut buf);
-
-        assert!(buf.contains("RAM_USAGE="));
-        assert!(!buf.contains("%"));
-    }
-
-    #[test]
-    fn test_get_memory_stats_swap() {
-        let mut s = System::new_all();
-        s.refresh_all();
-        let mut buf = String::new();
-
-        get_memory_stats(&s, &["swp_total", "swp_usage"], false, &mut buf);
-
+        assert!(buf.contains("SWP_FREE="));
         assert!(buf.contains("SWP_TOTAL="));
+        assert!(buf.contains("SWP_USED="));
         assert!(buf.contains("SWP_USAGE="));
     }
 

--- a/src/stats/memory.rs
+++ b/src/stats/memory.rs
@@ -4,12 +4,8 @@ use std::fmt::Write;
 use sysinfo::System;
 
 pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut String) {
-    let ram_flag_present = flags
-        .iter()
-        .any(|&flag| cli::all_ram_flags().contains(&flag));
-    let swp_flag_present = flags
-        .iter()
-        .any(|&flag| cli::all_swp_flags().contains(&flag));
+    let ram_flag_present = flags.iter().any(|&flag| cli::ALL_RAM_FLAGS.contains(&flag));
+    let swp_flag_present = flags.iter().any(|&flag| cli::ALL_SWP_FLAGS.contains(&flag));
 
     let (ram_total, ram_used, ram_usage_percentage) = if ram_flag_present {
         let ram_total = s.total_memory();

--- a/src/stats/memory.rs
+++ b/src/stats/memory.rs
@@ -1,8 +1,7 @@
+use super::{BYTES_PER_GB, PERCENT, unit};
 use crate::cli;
 use std::fmt::Write;
 use sysinfo::System;
-
-const BYTES_PER_GB: f32 = 1_073_741_824.0;
 
 pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut String) {
     let ram_flag_present = flags
@@ -16,7 +15,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
         let ram_total = s.total_memory();
         let ram_used = s.used_memory();
         let ram_usage_percentage = if ram_total > 0 {
-            ((ram_used as f32 / ram_total as f32) * 100.0).round() as u32
+            ((ram_used as f32 / ram_total as f32) * PERCENT).round() as u32
         } else {
             0
         };
@@ -28,7 +27,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
         let swp_total = s.total_swap();
         let swp_used = s.used_swap();
         let swp_usage_percentage = if swp_total > 0 {
-            ((swp_used as f32 / swp_total as f32) * 100.0).round() as u32
+            ((swp_used as f32 / swp_total as f32) * PERCENT).round() as u32
         } else {
             0
         };
@@ -40,7 +39,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
     for &flag in flags {
         match flag {
             "ram_available" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "RAM_AVAILABLE=\"{:.1}{unit}\" ",
@@ -48,7 +47,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
                 );
             }
             "ram_total" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "RAM_TOTAL=\"{:.1}{unit}\" ",
@@ -56,7 +55,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
                 );
             }
             "ram_used" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "RAM_USED=\"{:.1}{unit}\" ",
@@ -64,11 +63,11 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
                 );
             }
             "ram_usage" => {
-                let unit = if no_units { "" } else { "%" };
+                let unit = unit(no_units, "%");
                 let _ = write!(buf, "RAM_USAGE=\"{ram_usage_percentage}{unit}\" ");
             }
             "swp_free" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "SWP_FREE=\"{:.1}{unit}\" ",
@@ -76,7 +75,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
                 );
             }
             "swp_total" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "SWP_TOTAL=\"{:.1}{unit}\" ",
@@ -84,7 +83,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
                 );
             }
             "swp_used" => {
-                let unit = if no_units { "" } else { "GB" };
+                let unit = unit(no_units, "GB");
                 let _ = write!(
                     buf,
                     "SWP_USED=\"{:.1}{unit}\" ",
@@ -92,7 +91,7 @@ pub fn get_memory_stats(s: &System, flags: &[&str], no_units: bool, buf: &mut St
                 );
             }
             "swp_usage" => {
-                let unit = if no_units { "" } else { "%" };
+                let unit = unit(no_units, "%");
                 let _ = write!(buf, "SWP_USAGE=\"{swp_usage_percentage}{unit}\" ");
             }
             _ => {}

--- a/src/stats/mod.rs
+++ b/src/stats/mod.rs
@@ -1,4 +1,5 @@
 mod battery;
+mod constants;
 mod cpu;
 mod disk;
 mod memory;
@@ -9,9 +10,11 @@ mod uptime;
 use sysinfo::{CpuRefreshKind, MemoryRefreshKind, RefreshKind};
 
 pub use battery::get_battery_stats;
+pub use constants::*;
 pub use cpu::get_cpu_stats;
 pub use disk::get_disk_stats;
 pub use memory::get_memory_stats;
+pub use network::NetworkRateBaselines;
 pub use network::get_network_stats;
 pub use system::get_system_stats;
 pub use uptime::get_uptime_stats;

--- a/src/stats/network.rs
+++ b/src/stats/network.rs
@@ -47,6 +47,31 @@ fn rate_kib_per_sec(delta_bytes: u64, elapsed_secs: f64) -> u64 {
     ((delta_bytes / BYTES_PER_KB) as f64 / elapsed_secs).round() as u64
 }
 
+/// Computes rx/tx rates in `KiB/s` from the previous and current cumulative totals.
+///
+/// Returns `(0, 0)` when there is no previous baseline (first sighting of an
+/// interface) or when the cumulative counters wrapped around.
+fn compute_rates(
+    prev_rx: Option<u64>,
+    prev_tx: Option<u64>,
+    rx_total: u64,
+    tx_total: u64,
+    elapsed_secs: f64,
+) -> (u64, u64) {
+    let (Some(prev_rx), Some(prev_tx)) = (prev_rx, prev_tx) else {
+        return (0, 0);
+    };
+
+    if rx_total < prev_rx || tx_total < prev_tx {
+        return (0, 0);
+    }
+
+    (
+        rate_kib_per_sec(rx_total - prev_rx, elapsed_secs),
+        rate_kib_per_sec(tx_total - prev_tx, elapsed_secs),
+    )
+}
+
 pub fn get_network_stats(
     n: &Networks,
     interfaces: Option<&[String]>,
@@ -73,20 +98,17 @@ pub fn get_network_stats(
             let (rx_rate, tx_rate) = match baselines.by_interface.get(interface) {
                 Some(baseline) => {
                     let elapsed = baseline.at.elapsed().as_secs_f64();
-                    let rx_delta = rx_total.wrapping_sub(baseline.rx_total);
-                    let tx_delta = tx_total.wrapping_sub(baseline.tx_total);
-                    let wrapped = rx_total < baseline.rx_total || tx_total < baseline.tx_total;
+                    let rates = compute_rates(
+                        Some(baseline.rx_total),
+                        Some(baseline.tx_total),
+                        rx_total,
+                        tx_total,
+                        elapsed,
+                    );
 
                     baselines.reset(interface, rx_total, tx_total);
 
-                    if wrapped {
-                        (0, 0)
-                    } else {
-                        (
-                            rate_kib_per_sec(rx_delta, elapsed),
-                            rate_kib_per_sec(tx_delta, elapsed),
-                        )
-                    }
+                    rates
                 }
                 None => {
                     baselines.reset(interface, rx_total, tx_total);
@@ -135,11 +157,6 @@ mod tests {
     }
 
     #[test]
-    fn test_rate_kib_per_sec_zero_delta() {
-        assert_eq!(rate_kib_per_sec(0, 1.0), 0);
-    }
-
-    #[test]
     fn test_rate_kib_per_sec_pins_1024_divisor() {
         assert_eq!(rate_kib_per_sec(1500, 1.0), 1);
     }
@@ -147,5 +164,26 @@ mod tests {
     #[test]
     fn test_rate_kib_per_sec_fractional_elapsed() {
         assert_eq!(rate_kib_per_sec(1024, 0.5), 2);
+    }
+
+    #[test]
+    fn test_compute_rates_first_sighting_returns_zero() {
+        assert_eq!(compute_rates(None, None, 1000, 2000, 1.0), (0, 0));
+    }
+
+    #[test]
+    fn test_compute_rates_counter_wrap_returns_zero() {
+        assert_eq!(
+            compute_rates(Some(1000), Some(2000), 500, 2500, 1.0),
+            (0, 0)
+        );
+    }
+
+    #[test]
+    fn test_compute_rates_normal_delta() {
+        assert_eq!(
+            compute_rates(Some(2048), Some(4096), 4096, 6144, 1.0),
+            (2, 2)
+        );
     }
 }

--- a/src/stats/network.rs
+++ b/src/stats/network.rs
@@ -1,5 +1,36 @@
+use std::collections::HashMap;
 use std::fmt::Write;
+use std::time::Instant;
+
+use super::{BYTES_PER_KB, unit};
 use sysinfo::Networks;
+
+/// Per-interface counters used to compute transfer rates between ticks.
+struct InterfaceBaseline {
+    rx_total: u64,
+    tx_total: u64,
+    at: Instant,
+}
+
+/// Collector-owned baselines keyed by network interface name.
+#[derive(Default)]
+pub struct NetworkRateBaselines {
+    by_interface: HashMap<String, InterfaceBaseline>,
+}
+
+impl NetworkRateBaselines {
+    /// Resets the baseline for `interface` to the current cumulative totals.
+    fn reset(&mut self, interface: &str, rx_total: u64, tx_total: u64) {
+        self.by_interface.insert(
+            interface.to_owned(),
+            InterfaceBaseline {
+                rx_total,
+                tx_total,
+                at: Instant::now(),
+            },
+        );
+    }
+}
 
 fn network_key_suffix(interface: &str) -> String {
     interface
@@ -8,17 +39,21 @@ fn network_key_suffix(interface: &str) -> String {
         .collect()
 }
 
+/// Converts a byte delta and the elapsed time into a rate in `KiB/s`.
+fn rate_kib_per_sec(delta_bytes: u64, elapsed_secs: f64) -> u64 {
+    if elapsed_secs <= 0.0 {
+        return 0;
+    }
+    ((delta_bytes / BYTES_PER_KB) as f64 / elapsed_secs).round() as u64
+}
+
 pub fn get_network_stats(
     n: &Networks,
     interfaces: Option<&[String]>,
-    interval: u32,
+    baselines: &mut NetworkRateBaselines,
     no_units: bool,
     buf: &mut String,
 ) {
-    if interval == 0 {
-        return;
-    }
-
     let interfaces_to_check: Vec<&str> = match interfaces {
         Some(ifaces) => ifaces.iter().map(String::as_str).collect(),
         None => n
@@ -27,18 +62,42 @@ pub fn get_network_stats(
             .collect(),
     };
 
-    let unit = if no_units { "" } else { "KB/s" };
+    let unit = unit(no_units, "KiB/s");
 
     for interface in interfaces_to_check {
         if let Some(data) = n.get(interface) {
             let key_suffix = network_key_suffix(interface);
+            let rx_total = data.total_received();
+            let tx_total = data.total_transmitted();
+
+            let (rx_rate, tx_rate) = match baselines.by_interface.get(interface) {
+                Some(baseline) => {
+                    let elapsed = baseline.at.elapsed().as_secs_f64();
+                    let rx_delta = rx_total.wrapping_sub(baseline.rx_total);
+                    let tx_delta = tx_total.wrapping_sub(baseline.tx_total);
+                    let wrapped = rx_total < baseline.rx_total || tx_total < baseline.tx_total;
+
+                    baselines.reset(interface, rx_total, tx_total);
+
+                    if wrapped {
+                        (0, 0)
+                    } else {
+                        (
+                            rate_kib_per_sec(rx_delta, elapsed),
+                            rate_kib_per_sec(tx_delta, elapsed),
+                        )
+                    }
+                }
+                None => {
+                    baselines.reset(interface, rx_total, tx_total);
+                    (0, 0)
+                }
+            };
+
             let _ = write!(
                 buf,
-                "NETWORK_RX_{}=\"{}{unit}\" NETWORK_TX_{}=\"{}{unit}\" ",
-                key_suffix,
-                (data.received() / 1024) / interval as u64,
-                key_suffix,
-                (data.transmitted() / 1024) / interval as u64
+                "NETWORK_RX_{}=\"{rx_rate}{unit}\" NETWORK_TX_{}=\"{tx_rate}{unit}\" ",
+                key_suffix, key_suffix
             );
         }
     }
@@ -53,5 +112,40 @@ mod tests {
         assert_eq!(network_key_suffix("en0"), "en0");
         assert_eq!(network_key_suffix("bridge.100"), "bridge_100");
         assert_eq!(network_key_suffix("utun-1"), "utun_1");
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_typical_rate() {
+        assert_eq!(rate_kib_per_sec(2048, 2.0), 1);
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_sub_kib_rate_rounds_down() {
+        assert_eq!(rate_kib_per_sec(500, 1.0), 0);
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_rounds_to_nearest() {
+        assert_eq!(rate_kib_per_sec(3072, 1.0), 3);
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_zero_elapsed() {
+        assert_eq!(rate_kib_per_sec(1024, 0.0), 0);
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_zero_delta() {
+        assert_eq!(rate_kib_per_sec(0, 1.0), 0);
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_pins_1024_divisor() {
+        assert_eq!(rate_kib_per_sec(1500, 1.0), 1);
+    }
+
+    #[test]
+    fn test_rate_kib_per_sec_fractional_elapsed() {
+        assert_eq!(rate_kib_per_sec(1024, 0.5), 2);
     }
 }

--- a/src/stats/network.rs
+++ b/src/stats/network.rs
@@ -30,6 +30,12 @@ impl NetworkRateBaselines {
             },
         );
     }
+
+    /// Retains only baselines for interfaces that are currently active.
+    pub fn retain_active(&mut self, active_interfaces: &[&str]) {
+        self.by_interface
+            .retain(|interface, _| active_interfaces.contains(&interface.as_str()));
+    }
 }
 
 fn network_key_suffix(interface: &str) -> String {
@@ -44,7 +50,7 @@ fn rate_kib_per_sec(delta_bytes: u64, elapsed_secs: f64) -> u64 {
     if elapsed_secs <= 0.0 {
         return 0;
     }
-    ((delta_bytes / BYTES_PER_KB) as f64 / elapsed_secs).round() as u64
+    ((delta_bytes as f64 / BYTES_PER_KB as f64) / elapsed_secs).round() as u64
 }
 
 /// Computes rx/tx rates in `KiB/s` from the previous and current cumulative totals.
@@ -79,12 +85,12 @@ pub fn get_network_stats(
     no_units: bool,
     buf: &mut String,
 ) {
+    let active_interfaces: Vec<&str> = n.keys().map(|k| k.as_str()).collect();
+    baselines.retain_active(&active_interfaces);
+
     let interfaces_to_check: Vec<&str> = match interfaces {
         Some(ifaces) => ifaces.iter().map(String::as_str).collect(),
-        None => n
-            .keys()
-            .map(|interface_name| interface_name.as_str())
-            .collect(),
+        None => active_interfaces,
     };
 
     let unit = unit(no_units, "KiB/s");
@@ -162,8 +168,21 @@ mod tests {
     }
 
     #[test]
-    fn test_rate_kib_per_sec_fractional_elapsed() {
-        assert_eq!(rate_kib_per_sec(1024, 0.5), 2);
+    fn test_rate_kib_per_sec_fractional_sub_kib_rate() {
+        // 1000 bytes over 0.5s = 2000 B/s = 1.953 KiB/s -> rounds to 2 (would fail with integer div)
+        assert_eq!(rate_kib_per_sec(1000, 0.5), 2);
+    }
+
+    #[test]
+    fn test_network_baselines_retain_active() {
+        let mut baselines = NetworkRateBaselines::default();
+        baselines.reset("en0", 100, 100);
+        baselines.reset("utun0", 200, 200);
+
+        baselines.retain_active(&["en0"]);
+
+        assert!(baselines.by_interface.contains_key("en0"));
+        assert!(!baselines.by_interface.contains_key("utun0"));
     }
 
     #[test]

--- a/src/stats/system.rs
+++ b/src/stats/system.rs
@@ -46,3 +46,25 @@ pub fn get_system_stats(flags: &[&str], buf: &mut String) {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_system_stats_all_flags_emit_expected_keys() {
+        use crate::cli;
+
+        let mut buf = String::new();
+
+        get_system_stats(cli::ALL_SYSTEM_FLAGS, &mut buf);
+
+        assert!(buf.contains("ARCH="));
+        assert!(buf.contains("DISTRO="));
+        assert!(buf.contains("HOST_NAME="));
+        assert!(buf.contains("KERNEL_VERSION="));
+        assert!(buf.contains("SYSTEM_NAME="));
+        assert!(buf.contains(" OS_VERSION=\""));
+        assert!(buf.contains("LONG_OS_VERSION="));
+    }
+}

--- a/src/stats/uptime.rs
+++ b/src/stats/uptime.rs
@@ -35,13 +35,13 @@ const TIME_UNITS: &[TimeUnit] = &[
     },
 ];
 
-/// Formats an uptime duration as a sketchybar key/value pair.
+/// Formats an uptime duration as a sketchybar key/value pair into `buf`.
 ///
 /// Units are emitted in descending order of size (week to sec). An empty
 /// `flags` slice selects every unit. When no unit qualifies (for example all
 /// requested flags are unknown, or the duration is zero seconds), the smallest
 /// qualifying unit falls back to a zero value.
-fn format_uptime(uptime_secs: u64, flags: &[&str]) -> String {
+fn format_uptime(uptime_secs: u64, flags: &[&str], buf: &mut String) {
     let mut uptime_secs = uptime_secs;
 
     let sorted_flags: Vec<&str> = if flags.is_empty() {
@@ -62,8 +62,7 @@ fn format_uptime(uptime_secs: u64, flags: &[&str]) -> String {
         flags_vec
     };
 
-    let mut out = String::with_capacity(64);
-    let _ = write!(out, "UPTIME=\"");
+    let _ = write!(buf, "UPTIME=\"");
     let mut has_value = false;
 
     for &flag in &sorted_flags {
@@ -73,9 +72,9 @@ fn format_uptime(uptime_secs: u64, flags: &[&str]) -> String {
             let value = uptime_secs / unit.seconds;
             uptime_secs %= unit.seconds;
             if has_value {
-                let _ = write!(out, " ");
+                let _ = write!(buf, " ");
             }
-            let _ = write!(out, "{}{}", value, unit.suffix);
+            let _ = write!(buf, "{}{}", value, unit.suffix);
             has_value = true;
         }
     }
@@ -86,41 +85,52 @@ fn format_uptime(uptime_secs: u64, flags: &[&str]) -> String {
             .and_then(|flag| TIME_UNITS.iter().find(|u| u.name == *flag))
             .map(|unit| unit.suffix)
             .unwrap_or("s");
-        let _ = write!(out, "0{}", min_suffix);
+        let _ = write!(buf, "0{}", min_suffix);
     }
 
-    let _ = write!(out, "\" ");
-    out
+    let _ = write!(buf, "\" ");
 }
 
 pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
-    buf.push_str(&format_uptime(System::uptime(), flags));
+    format_uptime(System::uptime(), flags, buf);
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn format_uptime_helper(uptime_secs: u64, flags: &[&str]) -> String {
+        let mut buf = String::new();
+        format_uptime(uptime_secs, flags, &mut buf);
+        buf
+    }
+
     #[test]
     fn test_format_uptime_zero_seconds() {
-        assert_eq!(format_uptime(0, &[]), "UPTIME=\"0s\" ");
+        assert_eq!(format_uptime_helper(0, &[]), "UPTIME=\"0s\" ");
     }
 
     #[test]
     fn test_format_uptime_seconds_and_minutes() {
-        assert_eq!(format_uptime(61, &["min", "sec"]), "UPTIME=\"1m 1s\" ");
+        assert_eq!(
+            format_uptime_helper(61, &["min", "sec"]),
+            "UPTIME=\"1m 1s\" "
+        );
     }
 
     #[test]
     fn test_format_uptime_hours_and_minutes() {
-        assert_eq!(format_uptime(5400, &["hour", "min"]), "UPTIME=\"1h 30m\" ");
+        assert_eq!(
+            format_uptime_helper(5400, &["hour", "min"]),
+            "UPTIME=\"1h 30m\" "
+        );
     }
 
     #[test]
     fn test_format_uptime_all_units() {
         let secs = 7 * 24 * 3600 + 24 * 3600 + 3600 + 60 + 1;
         assert_eq!(
-            format_uptime(secs, &["week", "day", "hour", "min", "sec"]),
+            format_uptime_helper(secs, &["week", "day", "hour", "min", "sec"]),
             "UPTIME=\"1w 1d 1h 1m 1s\" "
         );
     }
@@ -128,14 +138,14 @@ mod tests {
     #[test]
     fn test_format_uptime_flags_reordered() {
         assert_eq!(
-            format_uptime(3660, &["sec", "hour", "min"]),
+            format_uptime_helper(3660, &["sec", "hour", "min"]),
             "UPTIME=\"1h 1m\" "
         );
     }
 
     #[test]
     fn test_format_uptime_empty_flags_fallback() {
-        assert_eq!(format_uptime(5400, &["bogus"]), "UPTIME=\"0s\" ");
+        assert_eq!(format_uptime_helper(5400, &["bogus"]), "UPTIME=\"0s\" ");
     }
 
     #[test]

--- a/src/stats/uptime.rs
+++ b/src/stats/uptime.rs
@@ -35,8 +35,14 @@ const TIME_UNITS: &[TimeUnit] = &[
     },
 ];
 
-pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
-    let mut uptime_secs = System::uptime();
+/// Formats an uptime duration as a sketchybar key/value pair.
+///
+/// Units are emitted in descending order of size (week to sec). An empty
+/// `flags` slice selects every unit. When no unit qualifies (for example all
+/// requested flags are unknown, or the duration is zero seconds), the smallest
+/// qualifying unit falls back to a zero value.
+fn format_uptime(uptime_secs: u64, flags: &[&str]) -> String {
+    let mut uptime_secs = uptime_secs;
 
     let sorted_flags: Vec<&str> = if flags.is_empty() {
         TIME_UNITS.iter().map(|u| u.name).collect()
@@ -56,7 +62,8 @@ pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
         flags_vec
     };
 
-    let _ = write!(buf, "UPTIME=\"");
+    let mut out = String::with_capacity(64);
+    let _ = write!(out, "UPTIME=\"");
     let mut has_value = false;
 
     for &flag in &sorted_flags {
@@ -66,9 +73,9 @@ pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
             let value = uptime_secs / unit.seconds;
             uptime_secs %= unit.seconds;
             if has_value {
-                let _ = write!(buf, " ");
+                let _ = write!(out, " ");
             }
-            let _ = write!(buf, "{}{}", value, unit.suffix);
+            let _ = write!(out, "{}{}", value, unit.suffix);
             has_value = true;
         }
     }
@@ -79,10 +86,15 @@ pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
             .and_then(|flag| TIME_UNITS.iter().find(|u| u.name == *flag))
             .map(|unit| unit.suffix)
             .unwrap_or("s");
-        let _ = write!(buf, "0{}", min_suffix);
+        let _ = write!(out, "0{}", min_suffix);
     }
 
-    let _ = write!(buf, "\" ");
+    let _ = write!(out, "\" ");
+    out
+}
+
+pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
+    buf.push_str(&format_uptime(System::uptime(), flags));
 }
 
 #[cfg(test)]
@@ -90,29 +102,40 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_get_uptime_stats_all_units() {
-        let mut buf = String::new();
-        get_uptime_stats(&["week", "day", "hour", "min", "sec"], &mut buf);
-
-        assert!(buf.starts_with("UPTIME=\""));
-        assert!(buf.ends_with("\" "));
+    fn test_format_uptime_zero_seconds() {
+        assert_eq!(format_uptime(0, &[]), "UPTIME=\"0s\" ");
     }
 
     #[test]
-    fn test_get_uptime_stats_single_unit() {
-        let mut buf = String::new();
-        get_uptime_stats(&["min"], &mut buf);
-
-        assert!(buf.contains("UPTIME=\""));
-        assert!(buf.contains("m"));
+    fn test_format_uptime_seconds_and_minutes() {
+        assert_eq!(format_uptime(61, &["min", "sec"]), "UPTIME=\"1m 1s\" ");
     }
 
     #[test]
-    fn test_get_uptime_stats_empty_flags() {
-        let mut buf = String::new();
-        get_uptime_stats(&[], &mut buf);
+    fn test_format_uptime_hours_and_minutes() {
+        assert_eq!(format_uptime(5400, &["hour", "min"]), "UPTIME=\"1h 30m\" ");
+    }
 
-        assert!(buf.contains("UPTIME=\""));
+    #[test]
+    fn test_format_uptime_all_units() {
+        let secs = 7 * 24 * 3600 + 24 * 3600 + 3600 + 60 + 1;
+        assert_eq!(
+            format_uptime(secs, &["week", "day", "hour", "min", "sec"]),
+            "UPTIME=\"1w 1d 1h 1m 1s\" "
+        );
+    }
+
+    #[test]
+    fn test_format_uptime_flags_reordered() {
+        assert_eq!(
+            format_uptime(3660, &["sec", "hour", "min"]),
+            "UPTIME=\"1h 1m\" "
+        );
+    }
+
+    #[test]
+    fn test_format_uptime_empty_flags_fallback() {
+        assert_eq!(format_uptime(5400, &["bogus"]), "UPTIME=\"0s\" ");
     }
 
     #[test]

--- a/src/stats/uptime.rs
+++ b/src/stats/uptime.rs
@@ -47,7 +47,12 @@ pub fn get_uptime_stats(flags: &[&str], buf: &mut String) {
             .filter(|&flag| TIME_UNITS.iter().any(|u| u.name == flag))
             .collect();
 
-        flags_vec.sort_by_key(|&flag| TIME_UNITS.iter().position(|u| u.name == flag).unwrap());
+        flags_vec.sort_by_key(|&flag| {
+            TIME_UNITS
+                .iter()
+                .position(|u| u.name == flag)
+                .unwrap_or(usize::MAX)
+        });
         flags_vec
     };
 


### PR DESCRIPTION
Implements six architecture improvements for correctness, network-rate accuracy, and stats plumbing, plus a CLI/best-practices cleanup.

## Commit 1 — `510453e` feat: fix correctness, decouple network rates, clean up stats plumbing

1. **Per-tick CPU temperature refresh** — the CPU stat list no longer caches temperatures between refresh ticks (`StatsContext` now carries `&'a mut Components` and refreshes per tick).
2. **Remove two panic paths** — uptime's `unwrap_or(usize::MAX)` and sketchybar's `unwrap_or("?")` replace `unwrap()`/`expect()` on hostname lookup and UTF-8 conversion.
3. **Lock-conflict notice** — when another `stats_provider` instance holds the SketchyBar lock, print a notice to stderr and exit 0 instead of exiting silently with an error.
4. **Byte-identical hygiene pass** — new `src/stats/constants.rs` (`BYTES_PER_GB`, `BYTES_PER_KB`, `PERCENT`, `SECONDS_PER_MINUTE`, `NO_TEMP_SENTINEL`, `unit()` helper), merged `--all`/per-flag dispatch, no behavior change.
5. **Network rates decoupled from refresh interval** — `NetworkRateBaselines` tracks cumulative byte totals + `Instant` per interface instead of per-tick deltas. Rates are now true per-second values and the false "0 KB/s" dips on list resets are gone.
6. **KB/s → KiB/s** label rename.

Adds 9 host-independent tests for the new pure unit/rate math (44 total).

## Commit 2 — `c245e6b` refactor(cli): declarative clap validation and const flag lists

- Manual interval/network-refresh-rate bound checks in `validate_cli` replaced with declarative `value_parser!(u32).range(1..=3600 / 1..=100)` — out-of-range input now fails at parse time (clap exit 2), and the bounds show in `--help`.
- `all_*_flags()` helpers converted to `pub const ALL_*_FLAGS: &[&str]` slices, parsed via `PossibleValuesParser`.
- Removed redundant `num_args = 0` on `--all` and `default_value_t = false` on `--verbose`/`--no-units`.
- CLI tests rewritten around `Cli::try_parse_from` + a `Command::debug_assert()` smoke test; removed a zero-assertion battery test.
- Fixed the stale verbose-output transcript in the README (all 13 `Cli` fields, `(Bar: sketchybar):` prefix).

Net −62 lines; test count unchanged at 44.

## Commit 3 — `a3a02af` test: harden the test suite — behavior tests over tautologies

Replaces 18 tautological/redundant/weak tests with 19 behavior tests that fail on real regressions (net 45 tests, was 44):

- **cli.rs** — dropped the 6 const-literal re-assertion tests and a redundant bounds test; added a round-trip test proving every `ALL_*_FLAGS` entry parses via `Cli::try_parse_from` (individually and all-at-once), an unknown-value rejection test for the six `PossibleValuesParser` args, and a defaults test pinning `DEFAULT_INTERVAL`/`DEFAULT_NETWORK_REFRESH_RATE` within their ranges
- **uptime.rs** — extracted pure `format_uptime()` (byte-identical output) with 6 deterministic tests for zero/rollover/multi-unit/filtering
- **network.rs** — extracted pure `compute_rates()` (byte-identical semantics) covering the first-sighting and wrap-around emit-0 paths
- **cpu/disk/memory/system** — anti-drift loop tests asserting every const flag makes its collector emit the expected key; system.rs gains its first test module; disk gains unknown-flag and no-units coverage
- **battery.rs** — tightened the with-units test to require both keys and a numeric percentage value
- **main.rs** — `validate_network_interfaces` rejects a bogus interface

## Commit 4 — `8f60b37` test: cover --all merged dispatch and network refresh tick

Adds two tests for `collect_stats_commands`:

- **`test_collect_stats_commands_all_dispatch_emits_every_flag`** — with `--all` and every stat flag unset, the per-tick buffer must contain every CPU/disk/memory/network/uptime key (the `--all` branch wins over empty processed flags, and `--all` routes network through the interfaces-unspecified path), must NOT contain any system keys (system stats are startup-only), and the refresh tick must increment below the rate.
- **`test_collect_stats_commands_network_refresh_tick_wraps`** — pins both tick branches: tick `rate − 1` wraps to 0 with a fresh interface list, tick 0 increments to 1.

All assertions are host-independent on macOS (N/A temp fallback, keys emitted with zero disks/swap, battery guarded conditionally).

## Commit 5 — `a7be59c` fix: rate precision, baseline pruning, temp-dir lock, uptime buffer writes

- **Rate precision** — `rate_kib_per_sec` divides in `f64` before scaling so sub-KiB deltas over fractional elapsed seconds no longer truncate to zero; the discriminating test `(1000 B, 0.5 s) → 2` replaces the old non-discriminating fractional test.
- **Baseline pruning** — stale per-interface baselines are pruned every tick via `NetworkRateBaselines::retain_active`, keeping memory bounded when interfaces churn (Wi-Fi/VPN).
- **Lock path** — the lock file now uses `std::env::temp_dir()` (per-user `TMPDIR` on macOS) instead of a hardcoded `/tmp` path; the lock test is host-state-independent (passes with or without a running instance, fails only if exclusive locking is removed).
- **Uptime buffer** — `format_uptime` writes directly into the caller's buffer, consistent with the other collectors.

## Verification

- `cargo build` clean, `cargo test` 49/49 pass, `cargo clippy --all-targets -- -D warnings` clean, `cargo fmt` clean

